### PR TITLE
Fix missing ThreadPoolExecutor import

### DIFF
--- a/moderation.py
+++ b/moderation.py
@@ -6,6 +6,7 @@ import queue
 import requests
 import re
 import math
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 # --- Message queue used for incoming messages from IRC ---
 message_queue = queue.Queue()


### PR DESCRIPTION
## Summary
- fix missing `ThreadPoolExecutor` import so moderation thread timeout works

## Testing
- `python -m py_compile moderation.py bot.py irc_client.py twitch_auth.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6869be0af770832098c7b128d4df66a5