### PR TITLE
Add completion mode for structured output

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -34,6 +34,7 @@ def main():
     model = config.get("model", "llama3")
     batch_interval = config.get("batch_interval", 2)
     moderation_timeout = config.get("moderation_timeout", 60)
+    use_completion = config.get("use_completion", False)
     max_openai_content_size = config.get("max_openai_content_size", 256000)
     max_rate_limit_retries = config.get("max_rate_limit_retries", 3)
     channel = twitch["channel"]
@@ -71,7 +72,8 @@ def main():
             model,
             twitch["client_id"],
             token_manager,
-            moderation_timeout
+            moderation_timeout,
+            use_completion
         ),
         daemon=True
     )

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 model: "phi4"
 batch_interval: 10
 moderation_timeout: 60
+use_completion: false
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697


### PR DESCRIPTION
## Summary
- allow using Ollama completion API with enforced JSON output
- thread workers pass `use_completion` from config
- document new `use_completion` option in config

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6869c3f76dd8832092932eac16883400