### PR TITLE
Fix thread shutdown handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -59,8 +59,7 @@ def main():
             twitch["client_id"],
             token_manager,
             batch_interval
-        ),
-        daemon=True
+        )
     )
     batch_thread.start()
 
@@ -74,8 +73,7 @@ def main():
             token_manager,
             moderation_timeout,
             use_completion
-        ),
-        daemon=True
+        )
     )
     run_thread.start()
 
@@ -86,8 +84,8 @@ def main():
         print("\n[BOT] Exiting on user interrupt...")
     finally:
         stop_event.set()
-        batch_thread.join(timeout=10)
-        run_thread.join(timeout=10)
+        batch_thread.join()
+        run_thread.join()
         loss_report()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wait for worker threads to exit instead of leaving them as daemons

## Testing
- `python -m py_compile bot.py irc_client.py moderation.py twitch_auth.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6869c6068b608320856691f18257026a